### PR TITLE
export xcoms parameters

### DIFF
--- a/airflow_prometheus_exporter/__init__.py
+++ b/airflow_prometheus_exporter/__init__.py
@@ -5,3 +5,17 @@
 __author__ = """Robinhood Markets, Inc."""
 __email__ = 'open-source@robinhood.com'
 __version__ = '1.0.4'
+
+
+import yaml
+import os
+
+dir = os.path.dirname(__file__)
+filename = os.path.join(dir, '../config.yaml')
+
+
+xcom_config = {}
+with open(filename) as file:
+    # The FullLoader parameter handles the conversion from YAML
+    # scalar values to Python the dictionary format
+    xcom_config = yaml.load(file, Loader=yaml.FullLoader)

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -2,7 +2,7 @@
 
 from contextlib import contextmanager
 
-from airflow.models import DagModel, DagRun, TaskInstance, TaskFail
+from airflow.models import DagModel, DagRun, TaskInstance, TaskFail, XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.settings import Session
 from airflow.utils.state import State
@@ -11,6 +11,12 @@ from flask_admin import BaseView, expose
 from prometheus_client import generate_latest, REGISTRY
 from prometheus_client.core import GaugeMetricFamily
 from sqlalchemy import and_, func
+from airflow.configuration import conf
+from airflow_prometheus_exporter import xcom_config
+
+import pickle
+import json
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 CANARY_DAG = 'canary_dag'
 
@@ -148,6 +154,44 @@ def get_task_failure_counts():
             TaskFail.dag_id,
             TaskFail.task_id,
         )
+
+def get_xcom_params(task_id):
+    #get latest task_id, join to xcom table
+    with session_scope(Session) as session:
+        max_execution_dt_query = session.query(
+            DagRun.dag_id,
+            func.max(DagRun.execution_date).label('max_execution_dt')
+        ).group_by(
+            DagRun.dag_id
+        ).subquery()
+
+        return session.query(
+            XCom.dag_id,
+            XCom.value
+        ).join(max_execution_dt_query,
+               and_(
+                   (
+                    XCom.dag_id == max_execution_dt_query.c.dag_id
+                   ),
+                   (XCom.execution_date == max_execution_dt_query.c.max_execution_dt
+                   )
+               )).filter(XCom.task_id == task_id).all()
+
+
+def extract_xcom_parameter(value):
+    enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
+    if enable_pickling:
+        return pickle.loads(value)
+    else:
+        try:
+            return json.loads(value.decode('UTF-8'))
+        except ValueError:
+            log = LoggingMixin().log
+            log.error("Could not deserialize the XCOM value from JSON. "
+                      "If you are using pickles instead of JSON "
+                      "for XCOM, then you need to enable pickle "
+                      "support for XCOM in your airflow config.")
+            raise
 
 
 def get_task_duration_info():
@@ -340,6 +384,24 @@ class MetricsCollector(object):
                 dag_scheduling_delay_value
             )
         yield dag_scheduler_delay
+
+
+        # XCOM parameters
+
+        xcom_params = GaugeMetricFamily(
+            'record_count',
+            'Record Count',
+            labels = ['dag_id', 'task_id']
+
+        )
+        for tasks in xcom_config['xcom_params']:
+            for param in get_xcom_params(tasks['task_id']):
+                xcom_value =  extract_xcom_parameter(param.value)
+                xcom_value = json.loads(xcom_value)
+                if tasks['key'] in xcom_value:
+                    xcom_params.add_metric([param.dag_id, tasks['task_id']],xcom_value[tasks['key']])
+
+        yield xcom_params
 
         task_scheduler_delay = GaugeMetricFamily(
             'airflow_task_scheduler_delay',

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,15 @@
+xcom_params:
+
+  -
+    task_id: publish_lif_file_metadata
+    key: record_count
+
+  -
+    task_id: map_csv_and_publish_metadata
+    key: record_count
+
+  -
+    task_id: convert_raw_to_lif
+    key: record_count
+
+


### PR DESCRIPTION
added code to extract metrics from the 'value' column in the xcom table and report as guage metrics. 

configurable in config.yaml as a collection of task_id, key pairs.



