### PR TITLE
Included filtering in queries to the Airflow Database

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -13,9 +13,10 @@ from flask import Response
 from flask_admin import BaseView, expose
 from prometheus_client import generate_latest, REGISTRY
 from prometheus_client.core import GaugeMetricFamily
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, text
 
 from airflow_prometheus_exporter.xcom_config import load_xcom_config
+from datetime import datetime, timedelta
 
 CANARY_DAG = "canary_dag"
 
@@ -43,6 +44,7 @@ def get_dag_state_info():
                 DagRun.state,
                 func.count(DagRun.state).label("count"),
             )
+            .filter(text("execution_date > NOW() - interval \'14 days\'"))
             .group_by(DagRun.dag_id, DagRun.state)
             .subquery()
         )
@@ -76,6 +78,7 @@ def get_dag_duration_info():
                 DagModel.is_paused == False,
                 DagRun.state == State.SUCCESS,
                 DagRun.end_date.isnot(None),
+                text("execution_date > NOW() - interval \'14 days\'"),
             )
             .group_by(DagRun.dag_id)
             .subquery()
@@ -139,8 +142,9 @@ def get_task_state_info():
                 TaskInstance.state,
                 func.count(TaskInstance.dag_id).label("value"),
             )
+            .filter(text("execution_date > NOW() - interval \'14 days\'"),)
             .group_by(
-                TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state
+                TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state,
             )
             .subquery()
         )


### PR DESCRIPTION
I've made some small changes in the code to allow for filtering of the datasets that are pulled from the Airflow DB. We were having an issue where the lack of that was timing out the export generation process, due to the size of the data being requested (we have ~4 years  with this airflow instance)

For now the fix I did just limits on the last 2 weeks worth of data, but it would be great if someone would also suggested a way to use Airflow variables and how we could ingest those into the process (I'm not the familiar with the process).