### PR TITLE
Stronger filtering

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -77,7 +77,6 @@ def get_dag_duration_info():
                 DagModel.is_paused == False,
                 DagRun.state == State.SUCCESS,
                 DagRun.end_date.isnot(None),
-                DagRun.start_date.isnot(None),
             )
             .group_by(DagRun.dag_id)
             .subquery()


### PR DESCRIPTION
It is posible for DagRun state to be None, and it is posible for TaskInstance state to be None.
This results in the plugin failing with the classic airflow mushroom cloud.

Many of hour dags run in an hourly basis, so to have execution_date without hour was inconvenient.


Sorry for this, i hope now is clearer
https://github.com/robinhood/airflow-prometheus-exporter/pull/19