### PR TITLE
Fix dag duration metric

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -99,6 +99,10 @@ def get_dag_duration_info():
                     ),
                 ),
             )
+            .filter(
+                TaskInstance.start_date.isnot(None),
+                TaskInstance.end_date.isnot(None),
+            )
             .group_by(
                 max_execution_dt_query.c.dag_id,
                 max_execution_dt_query.c.max_execution_dt,
@@ -119,10 +123,6 @@ def get_dag_duration_info():
                     DagRun.execution_date
                     == dag_start_dt_query.c.execution_date,
                 ),
-            )
-            .filter(
-                TaskInstance.start_date.isnot(None),
-                TaskInstance.end_date.isnot(None),
             )
             .all()
         )


### PR DESCRIPTION
The filter was causing an implicit cartesian join on TaskInstance in the outer query, making this metric appear multiple times for a single dag. I have moved the filter into the sub-query which is already joined with TaskInstance to prevent this cartesian join.

@abhishekray07 I hope you can take a look at this soon.