### PR TITLE
Add tags for dag and task's metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The exporter is based on this [prometheus exporter for Airflow](https://github.c
 
 The plugin has been tested with:
 
-- Airflow >= 1.10.4
+- Airflow >= 1.10.8
 - Python 3.6+
 
 The scheduler metrics assume that there is a DAG named `canary_dag`. In our setup, the `canary_dag` is a DAG which has a tasks which perform very simple actions such as establishing database connections. This DAG is used to test the uptime of the Airflow scheduler itself.

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -409,7 +409,7 @@ class MetricsCollector(object):
             labels=["tag", "dag_id", "owner", "status"],
         )
         for dag in dag_info:
-            d_state.add_metric([dag.name, dag.dag_id, dag.owners, dag.state], dag.count)
+            d_state.add_metric([dag.name or "none", dag.dag_id, dag.owners, dag.state], dag.count)
         yield d_state
 
         dag_duration = GaugeMetricFamily(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 install_requirements = [
-    'apache-airflow>=1.10.4',
+    'apache-airflow>=1.10.8',
     'prometheus_client>=0.4.2',
 ],
 


### PR DESCRIPTION
[Add tags to DAGs and use it for filtering in the UI](https://airflow.readthedocs.io/en/latest/howto/add-dag-tags.html)
the new feature in version 1.10.8, we can add tags in each dag and distinguish tasks or dags in different environments(test,pre,prod...) based on tags, this makes it easier to filter various alarm rules.

@abhishekray07 hope you can take it soon.