### PR TITLE
DENG-6767: DDNS: Add new network and business line columns to metadata table for Group Paging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black
+  - repo: local
+    hooks:
+      - id: build-docker-run-tests
+        name: build-docker-run-tests
+        entry: runtests
+        language: script
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The exporter is based on this [prometheus exporter for Airflow](https://github.c
 
 The plugin has been tested with:
 
-- Airflow >= 1.10.4
+- Airflow >= 1.10.8
 - Python 3.6+
 
 The scheduler metrics assume that there is a DAG named `canary_dag`. In our setup, the `canary_dag` is a DAG which has a tasks which perform very simple actions such as establishing database connections. This DAG is used to test the uptime of the Airflow scheduler itself.

--- a/airflow_prometheus_exporter/config.yaml
+++ b/airflow_prometheus_exporter/config.yaml
@@ -3,5 +3,3 @@ xcom_params:
   -
     task_id: all
     key: record_count
-
-

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -9,11 +9,11 @@ from flask import Response
 from flask_admin import BaseView, expose
 from prometheus_client import REGISTRY, generate_latest
 from prometheus_client.core import GaugeMetricFamily
-from sqlalchemy import and_, func, text
+from sqlalchemy import Column, String, and_, func
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow.configuration import conf
-from airflow.models import DagModel, DagRun, DagTag, TaskFail, TaskInstance, XCom
+from airflow.models import DagModel, DagRun, TaskFail, TaskInstance, XCom
 from airflow.plugins_manager import AirflowPlugin
 from airflow.settings import RBAC, Session
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -641,8 +641,8 @@ class MetricsCollector(object):
             expected_last_run = cron.get_prev(datetime)
             diff_from_expected = (
                 pendulum.instance(expected_last_run)
-                - pendulum.instance(tasks.max_execution_date).in_minutes()
-            )
+                - pendulum.instance(tasks.max_execution_date)
+            ).in_minutes()
             sla_time = dateparser.parse(
                 "today " + dag.sla_time, settings={"TIMEZONE": "America/Los_Angeles"}
             )

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -422,7 +422,7 @@ def get_sla_miss_dags():
         for dag in dags:
             dag_metrics = {
                 "dag_id": dag.dag_id,
-                "alert_target": dag.alert_target,
+                "alert_target": dag.alert_target or "missing",
                 "alert_external_classification": dag.alert_external_classification
                 or "missing",
                 "alert_report_classification": dag.alert_report_classification

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -615,7 +615,10 @@ class MetricsCollector(object):
                 expected_last_run
             ) - pendulum.instance(dag.max_execution_date)
             sla_time = dateparser.parse(dag.sla_time)
-            if pendulum.now("PST") > sla_time and diff_from_expected > dag.sla_interval:
+            if (
+                pendulum.now("America/Los_Angeles") > sla_time
+                and diff_from_expected > dag.sla_interval
+            ):
                 sla_miss_dags_metric.add_metric([dag.dag_id], 1)
             else:
                 sla_miss_dags_metric.add_metric([dag.dag_id], 0)
@@ -635,7 +638,7 @@ class MetricsCollector(object):
             ) - pendulum.instance(tasks.max_execution_date)
             sla_time = dateparser.parse(tasks.sla_time)
             if (
-                pendulum.now("PST") > sla_time
+                pendulum.now("America/Los_Angeles") > sla_time
                 and diff_from_expected > tasks.sla_interval
             ):
                 sla_miss_tasks_metric.add_metric([tasks.dag_id, tasks.task_id], 1)

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -386,6 +386,7 @@ def get_sla_miss_dags():
             session.query(
                 GapDagTag.dag_id,
                 GapDagTag.sla_interval,
+                GapDagTag.sla_time,
                 max_execution_dt_query.c.schedule_interval,
                 max_execution_dt_query.c.max_execution_date,
             )
@@ -424,6 +425,7 @@ def get_sla_miss_tasks():
                 GapDagTag.task_id,
                 max_execution_date_query.c.max_execution_date,
                 GapDagTag.sla_interval,
+                GapDagTag.sla_time,
             )
             .join(
                 max_execution_date_query,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -370,7 +370,7 @@ def get_sla_miss_dags():
             session.query(
                 DagRun.dag_id,
                 DagModel.schedule_interval,
-                func.max(DagRun.execution_date).label("max_execution_dt"),
+                func.max(DagRun.execution_date).label("max_execution_date"),
             )
             .join(DagModel, DagModel.dag_id == DagRun.dag_id)
             .filter(
@@ -387,7 +387,7 @@ def get_sla_miss_dags():
                 GapDagTag.dag_id,
                 GapDagTag.sla_interval,
                 max_execution_dt_query.c.schedule_interval,
-                max_execution_dt_query.c.max_execution_dt,
+                max_execution_dt_query.c.max_execution_date,
             )
             .join(
                 max_execution_dt_query,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -450,10 +450,10 @@ def get_sla_miss_dags():
             else:
                 sla_time = dateparser.parse("today " + dag.sla_time)
                 expected_last_run = sla_time.replace(
-                    hours=0, minutes=0, seconds=0, microsecond=0
+                    hour=0, minute=0, second=0, microsecond=0
                 )
                 max_execution_date = max_execution_date.replace(
-                    hours=0, minutes=0, seconds=0, microsecond=0
+                    hour=0, minute=0, second=0, microsecond=0
                 )
                 diff_from_expected = pendulum.instance(
                     expected_last_run
@@ -552,10 +552,10 @@ def get_sla_miss_tasks():
             else:
                 sla_time = dateparser.parse("today " + task.sla_time)
                 expected_last_run = sla_time.replace(
-                    hours=0, minutes=0, seconds=0, microsecond=0
+                    hour=0, minute=0, second=0, microsecond=0
                 )
                 max_execution_date = task.max_execution_date.replace(
-                    hours=0, minutes=0, seconds=0, microsecond=0
+                    hour=0, minute=0, second=0, microsecond=0
                 )
                 diff_from_expected = pendulum.instance(
                     expected_last_run

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -42,7 +42,7 @@ with session_scope(Session) as session:
     Base = declarative_base(session.get_bind())
 
     class DelayAlertMetaData(Base):
-        __tablename__ = "gap_dag_tag"
+        __tablename__ = "delay_alert_metadata"
         dag_id = Column(String, primary_key=True)  # hack to have dag_id as PK
         task_id = Column(String)
         cadence = Column(String)

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -493,8 +493,6 @@ class MetricsCollector(object):
                 dag.end_date - dag.start_date
             ).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
-
-
         yield dag_duration
 
         # Scheduler Metrics

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -16,6 +16,7 @@ from flask_admin import BaseView, expose
 from prometheus_client import generate_latest, REGISTRY
 from prometheus_client.core import GaugeMetricFamily
 from sqlalchemy import and_, func
+from sqlalchemy.ext.declarative import declarative_base
 
 from airflow_prometheus_exporter.xcom_config import load_xcom_config
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -539,7 +539,7 @@ def get_sla_miss_tasks():
                 expected_last_run = cron.get_prev(datetime)
                 diff_from_expected = (
                     pendulum.instance(expected_last_run)
-                    - pendulum.instance(task.max_execution_date)
+                    - pendulum.instance(max_execution_date)
                 ).in_minutes()
                 sla_time = dateparser.parse(
                     "today " + task.sla_time,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -427,9 +427,9 @@ def get_sla_miss_dags():
                 or max_execution_date > dag.latest_successful_run
             ):
                 session.query(GapDagTag).filter(GapDagTag.dag_id == dag.dag_id).update(
-                    {GapDagTag.latest_successful_run: max_execution_date},
-                    synchronize_session=False,
+                    {GapDagTag.latest_successful_run: max_execution_date}
                 )
+                session.commit()
             else:
                 max_execution_date = dag.latest_successful_run
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -611,15 +611,15 @@ class MetricsCollector(object):
         for dag in get_sla_miss_dags():
             cron = croniter.croniter(dag.schedule_interval)
             expected_last_run = cron.get_prev(datetime)
-            diff_from_expected = pendulum.instance(
-                expected_last_run
-            ) - pendulum.instance(dag.max_execution_date)
+            diff_from_expected = (
+                pendulum.instance(expected_last_run)
+                - pendulum.instance(dag.max_execution_date)
+            ).in_minutes()
             sla_time = dateparser.parse(
                 "today " + dag.sla_time, settings={"TIMEZONE": "America/Los_Angeles"}
             )
-            if (
-                pendulum.now("America/Los_Angeles") > sla_time
-                and diff_from_expected > dag.sla_interval
+            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
+                dag.sla_interval * 24 * 60
             ):
                 sla_miss_dags_metric.add_metric([dag.dag_id], 1)
             else:
@@ -635,15 +635,15 @@ class MetricsCollector(object):
         for tasks in get_sla_miss_tasks():
             cron = croniter.croniter(tasks.schedule_interval)
             expected_last_run = cron.get_prev(datetime)
-            diff_from_expected = pendulum.instance(
-                expected_last_run
-            ) - pendulum.instance(tasks.max_execution_date)
+            diff_from_expected = (
+                pendulum.instance(expected_last_run)
+                - pendulum.instance(tasks.max_execution_date).in_minutes()
+            )
             sla_time = dateparser.parse(
                 "today " + dag.sla_time, settings={"TIMEZONE": "America/Los_Angeles"}
             )
-            if (
-                pendulum.now("America/Los_Angeles") > sla_time
-                and diff_from_expected > tasks.sla_interval
+            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
+                tasks.sla_interval * 24 * 60
             ):
                 sla_miss_tasks_metric.add_metric([tasks.dag_id, tasks.task_id], 1)
             else:

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -502,6 +502,7 @@ def get_sla_miss_tasks():
                 GapDagTag.sla_time,
                 GapDagTag.alert_target,
                 GapDagTag.alert_classification,
+                GapDagTag.latest_successful_run,
             )
             .join(
                 max_execution_date_query,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -200,7 +200,7 @@ def get_task_state_info():
             )
             .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
             .filter(
-                #DagModel.is_active == True,  # noqa
+                DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
             )
             .outerjoin(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -426,8 +426,10 @@ def get_sla_miss_dags():
                 dag.latest_successful_run is None
                 or max_execution_date > dag.latest_successful_run
             ):
-
-                dag.latest_successful_run = max_execution_date
+                session.query(GapDagTag).filter(GapDagTag.dag_id == dag.dag_id).update(
+                    {GapDagTag.latest_successful_run: max_execution_date},
+                    synchronize_session=False,
+                )
             else:
                 max_execution_date = dag.latest_successful_run
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -406,6 +406,7 @@ def get_sla_miss_tasks():
             session.query(
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
+                DagModel.schedule_interval,
                 func.max(TaskInstance.execution_date).label("max_execution_date"),
             )
             .join(DagModel, DagModel.dag_id == TaskInstance.dag_id)
@@ -415,7 +416,9 @@ def get_sla_miss_tasks():
                 TaskInstance.state == State.SUCCESS,
                 TaskInstance.execution_date > min_date_to_filter,
             )
-            .group_by(TaskInstance.dag_id, TaskInstance.task_id)
+            .group_by(
+                TaskInstance.dag_id, TaskInstance.task_id, DagModel.schedule_interval
+            )
             .subquery()
         )
 
@@ -424,6 +427,7 @@ def get_sla_miss_tasks():
                 GapDagTag.dag_id,
                 GapDagTag.task_id,
                 max_execution_date_query.c.max_execution_date,
+                max_execution_date_query.c.schedule_interval,
                 GapDagTag.sla_interval,
                 GapDagTag.sla_time,
             )

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -564,9 +564,9 @@ def get_sla_miss_tasks():
             if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
                 task.sla_interval * 24 * 60
             ):
-                task["sla_miss"] = 1
+                task_metrics["sla_miss"] = 1
             elif diff_from_expected > ((task.sla_interval + 1) * 24 * 60):
-                task["sla_miss"] = 1
+                task_metrics["sla_miss"] = 1
             sla_miss_tasks.append(task_metrics)
         return sla_miss_tasks
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -443,7 +443,7 @@ def get_sla_miss_tasks():
             session.query(
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
-                func.max(TaskInstance.execution_date).label("execution_date")
+                func.max(TaskInstance.execution_date).label("max_execution_date")
             )
             .join(DagModel, DagModel.dag_id == TaskInstance.dag_id)
             .filter(
@@ -460,7 +460,7 @@ def get_sla_miss_tasks():
             session.query(
                 GapDagTag.dag_id,
                 GapDagTag.task_id,
-                max_execution_date_query.c.execution_date,
+                max_execution_date_query.c.max_execution_date,
                 GapDagTag.sla_interval,
             )
             .join(
@@ -658,7 +658,7 @@ class MetricsCollector(object):
         )
 
         for tasks in get_sla_miss_tasks():
-            if current_dt.diff(tasks.execution_date).in_hours() > tasks.sla_interval:
+            if current_dt.diff(tasks.max_execution_date).in_hours() > tasks.sla_interval:
                 sla_miss_tasks_metric.add_metric([tasks.dag_id, tasks.task_id], 1)
             else:
                 sla_miss_tasks_metric.add_metric([tasks.dag_id, tasks.task_id], 0)

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -471,11 +471,11 @@ def get_sla_miss_dags():
                     - pendulum.instance(max_execution_date)
                 ).in_minutes()
 
-            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
-                dag.sla_interval * 24 * 60
-            ):
+            if pendulum.now(
+                "America/Los_Angeles"
+            ) > sla_time and diff_from_expected >= (dag.sla_interval * 24 * 60):
                 dag_metrics["sla_miss"] = 1
-            elif diff_from_expected > ((dag.sla_interval + 1) * 24 * 60):
+            elif diff_from_expected >= ((dag.sla_interval + 1) * 24 * 60):
                 dag_metrics["sla_miss"] = 1
             sla_miss_dags_metrics.append(dag_metrics)
         return sla_miss_dags_metrics
@@ -580,11 +580,11 @@ def get_sla_miss_tasks():
                     - pendulum.instance(max_execution_date)
                 ).in_minutes()
 
-            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
-                task.sla_interval * 24 * 60
-            ):
+            if pendulum.now(
+                "America/Los_Angeles"
+            ) > sla_time and diff_from_expected >= (task.sla_interval * 24 * 60):
                 task_metrics["sla_miss"] = 1
-            elif diff_from_expected > ((task.sla_interval + 1) * 24 * 60):
+            elif diff_from_expected >= ((task.sla_interval + 1) * 24 * 60):
                 task_metrics["sla_miss"] = 1
             sla_miss_tasks.append(task_metrics)
         return sla_miss_tasks

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -34,6 +34,12 @@ def session_scope(session):
         session.close()
 
 
+with session_scope(Session) as session:
+    Base = declarative_base(session.get_bind())
+    class GapDagTag(Base):
+        __tablename__ = 'gap_dag_tag'
+        __table_args__ = {'autoload': True}
+
 ######################
 # DAG Related Metrics
 ######################
@@ -43,6 +49,7 @@ def get_dag_state_info():
     """Number of DAG Runs with particular state."""
     min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
+
         dag_status_query = (
             session.query(
                 DagTag.name,
@@ -67,12 +74,18 @@ def get_dag_state_info():
                 dag_status_query.c.state,
                 dag_status_query.c.count,
                 DagModel.owners,
+                GapDagTag.cadence,
+                GapDagTag.severerity,
+                GapDagTag.alert_target,
+                GapDagTag.instant_slack_alert,
+                GapDagTag.alert_classification,
             )
             .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
             .filter(
                 DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
             )
+            .outerjoin(GapDagTag, GapDagTag.dag_id == dag_status_query.c.dag_id)
             .all()
         )
 
@@ -179,11 +192,22 @@ def get_task_state_info():
                 task_status_query.c.state,
                 task_status_query.c.value,
                 DagModel.owners,
+                GapDagTag.cadence,
+                GapDagTag.severerity,
+                GapDagTag.alert_target,
+                GapDagTag.instant_slack_alert,
+                GapDagTag.alert_classification,
             )
             .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
             .filter(
-                DagModel.is_active == True,  # noqa
+                #DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
+            )
+            .outerjoin(
+                GapDagTag,
+                (GapDagTag.dag_id == task_status_query.c.dag_id)
+                &
+                (GapDagTag.task_id == task_status_query.c.task_id),
             )
             .all()
         )
@@ -387,12 +411,24 @@ class MetricsCollector(object):
         t_state = GaugeMetricFamily(
             "airflow_task_status",
             "Shows the number of task instances with particular status",
-            labels=["tag", "dag_id", "task_id", "owner", "status"],
+            labels=["tag", "dag_id", "task_id", "owner", "status", "cadence", "severity",
+                "alert_target", "instant_slack_alert", "alert_classification"],
         )
         for task in task_info:
             t_state.add_metric(
-                [task.name or "none", task.dag_id, task.task_id, task.owners, task.state or "none"],
-                task.value,
+                [
+                    task.name or "none",
+                    task.dag_id,
+                    task.task_id,
+                    task.owners,
+                    task.state or "none",
+                    task.cadence or "none",
+                    task.severerity or "none",
+                    task.alert_target or "none",
+                    task.instant_slack_alert or "none",
+                    task.alert_classification or "none"
+                ],
+                task.value
             )
         yield t_state
 
@@ -427,10 +463,24 @@ class MetricsCollector(object):
         d_state = GaugeMetricFamily(
             "airflow_dag_status",
             "Shows the number of dag starts with this status",
-            labels=["tag", "dag_id", "owner", "status"],
+            labels=["tag", "dag_id", "owner", "status", "cadence", "severity",
+                "alert_target", "instant_slack_alert", "alert_classification"],
         )
         for dag in dag_info:
-            d_state.add_metric([dag.name or "none", dag.dag_id, dag.owners, dag.state], dag.count)
+            d_state.add_metric(
+                [
+                    dag.name or "none",
+                    dag.dag_id,
+                    dag.owners,
+                    dag.state,
+                    dag.cadence or "none",
+                    dag.severerity or "none",
+                    dag.alert_target or "none",
+                    dag.instant_slack_alert or "none",
+                    dag.alert_classification or "none"
+                ],
+                dag.count
+            )
         yield d_state
 
         dag_duration = GaugeMetricFamily(
@@ -443,6 +493,8 @@ class MetricsCollector(object):
                 dag.end_date - dag.start_date
             ).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
+
+
         yield dag_duration
 
         # Scheduler Metrics

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -455,9 +455,10 @@ def get_sla_miss_dags():
                 max_execution_date = max_execution_date.replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
-                diff_from_expected = pendulum.instance(
-                    expected_last_run
-                ) - pendulum.instance(max_execution_date)
+                diff_from_expected = (
+                    pendulum.instance(expected_last_run)
+                    - pendulum.instance(max_execution_date)
+                ).in_minutes()
 
             if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
                 dag.sla_interval * 24 * 60
@@ -557,9 +558,10 @@ def get_sla_miss_tasks():
                 max_execution_date = task.max_execution_date.replace(
                     hour=0, minute=0, second=0, microsecond=0
                 )
-                diff_from_expected = pendulum.instance(
-                    expected_last_run
-                ) - pendulum.instance(max_execution_date)
+                diff_from_expected = (
+                    pendulum.instance(expected_last_run)
+                    - pendulum.instance(max_execution_date)
+                ).in_minutes()
 
             if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
                 task.sla_interval * 24 * 60

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -53,19 +53,14 @@ def get_dag_state_info():
 
         dag_status_query = (
             session.query(
-                DagTag.name,
-                DagRun.dag_id,
-                DagRun.state,
-                func.count(DagRun.state).label("count"),
+                DagRun.dag_id, DagRun.state, func.count(DagRun.state).label("count")
             )
             .filter(DagRun.external_trigger == False, DagRun.state.isnot(None))  # noqa
-            .outerjoin(DagTag, DagTag.dag_id == DagRun.dag_id)
-            .group_by(DagTag.name, DagRun.dag_id, DagRun.state)
+            .group_by(DagRun.dag_id, DagRun.state)
             .subquery()
         )
         return (
             session.query(
-                dag_status_query.c.name,
                 dag_status_query.c.dag_id,
                 dag_status_query.c.state,
                 dag_status_query.c.count,
@@ -158,24 +153,16 @@ def get_task_state_info():
     with session_scope(Session) as session:
         task_status_query = (
             session.query(
-                DagTag.name,
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
                 TaskInstance.state,
                 func.count(TaskInstance.dag_id).label("value"),
             )
-            .outerjoin(DagTag, DagTag.dag_id == TaskInstance.dag_id)
-            .group_by(
-                DagTag.name,
-                TaskInstance.dag_id,
-                TaskInstance.task_id,
-                TaskInstance.state,
-            )
+            .group_by(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state)
             .subquery()
         )
         return (
             session.query(
-                task_status_query.c.name,
                 task_status_query.c.dag_id,
                 task_status_query.c.task_id,
                 task_status_query.c.state,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -400,7 +400,6 @@ class MetricsCollector(object):
             "airflow_task_status",
             "Shows the number of task instances with particular status",
             labels=[
-                "tag",
                 "dag_id",
                 "task_id",
                 "owner",
@@ -415,7 +414,6 @@ class MetricsCollector(object):
         for task in task_info:
             t_state.add_metric(
                 [
-                    task.name or "none",
                     task.dag_id,
                     task.task_id,
                     task.owners,
@@ -462,7 +460,6 @@ class MetricsCollector(object):
             "airflow_dag_status",
             "Shows the number of dag starts with this status",
             labels=[
-                "tag",
                 "dag_id",
                 "owner",
                 "status",
@@ -476,7 +473,6 @@ class MetricsCollector(object):
         for dag in dag_info:
             d_state.add_metric(
                 [
-                    dag.name or "none",
                     dag.dag_id,
                     dag.owners,
                     dag.state,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -1,25 +1,24 @@
 """Prometheus exporter for Airflow."""
 import json
-import pickle
-import pendulum
 import os
+import pickle
 from contextlib import contextmanager
 
-from airflow.configuration import conf
-from airflow.models import DagModel, DagRun, TaskInstance, TaskFail, XCom, DagTag
-from airflow.plugins_manager import AirflowPlugin
-from airflow.settings import RBAC, Session
-from airflow.utils.state import State
-from airflow.utils.log.logging_mixin import LoggingMixin
+import pendulum
 from flask import Response
 from flask_admin import BaseView, expose
-from prometheus_client import generate_latest, REGISTRY
+from prometheus_client import REGISTRY, generate_latest
 from prometheus_client.core import GaugeMetricFamily
 from sqlalchemy import and_, func
 from sqlalchemy.ext.declarative import declarative_base
 
+from airflow.configuration import conf
+from airflow.models import DagModel, DagRun, DagTag, TaskFail, TaskInstance, XCom
+from airflow.plugins_manager import AirflowPlugin
+from airflow.settings import RBAC, Session
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
 from airflow_prometheus_exporter.xcom_config import load_xcom_config
-
 
 CANARY_DAG = "canary_dag"
 RETENTION_TIME = os.environ.get("PROMETHEUS_METRICS_DAYS", 14)
@@ -37,9 +36,11 @@ def session_scope(session):
 
 with session_scope(Session) as session:
     Base = declarative_base(session.get_bind())
+
     class GapDagTag(Base):
-        __tablename__ = 'gap_dag_tag'
-        __table_args__ = {'autoload': True}
+        __tablename__ = "gap_dag_tag"
+        __table_args__ = {"autoload": True}
+
 
 ######################
 # DAG Related Metrics
@@ -48,7 +49,6 @@ with session_scope(Session) as session:
 
 def get_dag_state_info():
     """Number of DAG Runs with particular state."""
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
 
         dag_status_query = (
@@ -58,13 +58,8 @@ def get_dag_state_info():
                 DagRun.state,
                 func.count(DagRun.state).label("count"),
             )
-            .filter(
-                DagRun.execution_date > min_date_to_filter,
-                DagRun.state.isnot(None)
-            )
-            .outerjoin(
-                DagTag, DagTag.dag_id == DagRun.dag_id
-            )
+            .filter(DagRun.external_trigger == False, DagRun.state.isnot(None))  # noqa
+            .outerjoin(DagTag, DagTag.dag_id == DagRun.dag_id)
             .group_by(DagTag.name, DagRun.dag_id, DagRun.state)
             .subquery()
         )
@@ -80,13 +75,12 @@ def get_dag_state_info():
                 GapDagTag.alert_target,
                 GapDagTag.instant_slack_alert,
                 GapDagTag.alert_classification,
+                GapDagTag.sla,
             )
             .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
-            .filter(
-                DagModel.is_active == True,  # noqa
-                DagModel.is_paused == False,
-            )
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
             .outerjoin(GapDagTag, GapDagTag.dag_id == dag_status_query.c.dag_id)
+            .filter(GapDagTag.task_id.is_(None))
             .all()
         )
 
@@ -97,8 +91,7 @@ def get_dag_duration_info():
     with session_scope(Session) as session:
         max_execution_dt_query = (
             session.query(
-                DagRun.dag_id,
-                func.max(DagRun.execution_date).label("max_execution_dt"),
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
             )
             .join(DagModel, DagModel.dag_id == DagRun.dag_id)
             .filter(
@@ -106,7 +99,7 @@ def get_dag_duration_info():
                 DagModel.is_paused == False,
                 DagRun.state == State.SUCCESS,
                 DagRun.end_date.isnot(None),
-                DagRun.execution_date > min_date_to_filter
+                DagRun.execution_date > min_date_to_filter,
             )
             .group_by(DagRun.dag_id)
             .subquery()
@@ -115,9 +108,7 @@ def get_dag_duration_info():
         dag_start_dt_query = (
             session.query(
                 max_execution_dt_query.c.dag_id,
-                max_execution_dt_query.c.max_execution_dt.label(
-                    "execution_date"
-                ),
+                max_execution_dt_query.c.max_execution_dt.label("execution_date"),
                 func.min(TaskInstance.start_date).label("start_date"),
             )
             .join(
@@ -126,13 +117,12 @@ def get_dag_duration_info():
                     TaskInstance.dag_id == max_execution_dt_query.c.dag_id,
                     (
                         TaskInstance.execution_date
-                        == max_execution_dt_query.c.max_execution_dt
+                        == max_execution_dt_query.c.max_execution_dt  # noqa
                     ),
                 ),
             )
             .filter(
-                TaskInstance.start_date.isnot(None),
-                TaskInstance.end_date.isnot(None),
+                TaskInstance.start_date.isnot(None), TaskInstance.end_date.isnot(None)
             )
             .group_by(
                 max_execution_dt_query.c.dag_id,
@@ -151,8 +141,7 @@ def get_dag_duration_info():
                 DagRun,
                 and_(
                     DagRun.dag_id == dag_start_dt_query.c.dag_id,
-                    DagRun.execution_date
-                    == dag_start_dt_query.c.execution_date,
+                    DagRun.execution_date == dag_start_dt_query.c.execution_date,
                 ),
             )
             .all()
@@ -166,7 +155,6 @@ def get_dag_duration_info():
 
 def get_task_state_info():
     """Number of task instances with particular state."""
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
         task_status_query = (
             session.query(
@@ -176,12 +164,12 @@ def get_task_state_info():
                 TaskInstance.state,
                 func.count(TaskInstance.dag_id).label("value"),
             )
-            .filter(TaskInstance.execution_date > min_date_to_filter)
-            .outerjoin(
-                DagTag, DagTag.dag_id == TaskInstance.dag_id
-            )
+            .outerjoin(DagTag, DagTag.dag_id == TaskInstance.dag_id)
             .group_by(
-                DagTag.name, TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state,
+                DagTag.name,
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+                TaskInstance.state,
             )
             .subquery()
         )
@@ -198,18 +186,16 @@ def get_task_state_info():
                 GapDagTag.alert_target,
                 GapDagTag.instant_slack_alert,
                 GapDagTag.alert_classification,
+                GapDagTag.sla,
             )
             .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
-            .filter(
-                DagModel.is_active == True,  # noqa
-                DagModel.is_paused == False,
-            )
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
             .outerjoin(
                 GapDagTag,
                 (GapDagTag.dag_id == task_status_query.c.dag_id)
-                &
-                (GapDagTag.task_id == task_status_query.c.task_id),
+                & (GapDagTag.task_id == task_status_query.c.task_id),  # noqa
             )
+            .filter(GapDagTag.task_id.isnot(None))
             .all()
         )
 
@@ -223,12 +209,9 @@ def get_task_failure_counts():
                 TaskFail.task_id,
                 func.count(TaskFail.dag_id).label("count"),
             )
-            .join(DagModel, DagModel.dag_id == TaskFail.dag_id,)
-            .filter(
-                DagModel.is_active == True,  # noqa
-                DagModel.is_paused == False,
-            )
-            .group_by(TaskFail.dag_id, TaskFail.task_id,)
+            .join(DagModel, DagModel.dag_id == TaskFail.dag_id)
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
+            .group_by(TaskFail.dag_id, TaskFail.task_id)
         )
 
 
@@ -237,12 +220,9 @@ def get_xcom_params(task_id):
     with session_scope(Session) as session:
         max_execution_dt_query = (
             session.query(
-                DagRun.dag_id,
-                func.max(DagRun.execution_date).label("max_execution_dt"),
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
             )
-            .filter(
-                TaskInstance.state.isnot(None)
-            )
+            .filter(TaskInstance.state.isnot(None))
             .group_by(DagRun.dag_id)
             .subquery()
         )
@@ -251,10 +231,7 @@ def get_xcom_params(task_id):
             max_execution_dt_query,
             and_(
                 (XCom.dag_id == max_execution_dt_query.c.dag_id),
-                (
-                    XCom.execution_date
-                    == max_execution_dt_query.c.max_execution_dt
-                ),
+                (XCom.execution_date == max_execution_dt_query.c.max_execution_dt),
             ),
         )
         if task_id == "all":
@@ -292,10 +269,9 @@ def get_task_duration_info():
     with session_scope(Session) as session:
         max_execution_dt_query = (
             session.query(
-                DagRun.dag_id,
-                func.max(DagRun.execution_date).label("max_execution_dt"),
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
             )
-            .join(DagModel, DagModel.dag_id == DagRun.dag_id,)
+            .join(DagModel, DagModel.dag_id == DagRun.dag_id)
             .filter(
                 DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
@@ -320,7 +296,7 @@ def get_task_duration_info():
                     (TaskInstance.dag_id == max_execution_dt_query.c.dag_id),
                     (
                         TaskInstance.execution_date
-                        == max_execution_dt_query.c.max_execution_dt
+                        == max_execution_dt_query.c.max_execution_dt  # noqa
                     ),
                 ),
             )
@@ -342,10 +318,8 @@ def get_dag_scheduler_delay():
     """Compute DAG scheduling delay."""
     with session_scope(Session) as session:
         return (
-            session.query(
-                DagRun.dag_id, DagRun.execution_date, DagRun.start_date,
-            )
-            .filter(DagRun.dag_id == CANARY_DAG,)
+            session.query(DagRun.dag_id, DagRun.execution_date, DagRun.start_date)
+            .filter(DagRun.dag_id == CANARY_DAG)
             .order_by(DagRun.execution_date.desc())
             .limit(1)
             .all()
@@ -357,12 +331,10 @@ def get_task_scheduler_delay():
     with session_scope(Session) as session:
         task_status_query = (
             session.query(
-                TaskInstance.queue,
-                func.max(TaskInstance.start_date).label("max_start"),
+                TaskInstance.queue, func.max(TaskInstance.start_date).label("max_start")
             )
             .filter(
-                TaskInstance.dag_id == CANARY_DAG,
-                TaskInstance.queued_dttm.isnot(None),
+                TaskInstance.dag_id == CANARY_DAG, TaskInstance.queued_dttm.isnot(None)
             )
             .group_by(TaskInstance.queue)
             .subquery()
@@ -381,10 +353,7 @@ def get_task_scheduler_delay():
                     TaskInstance.start_date == task_status_query.c.max_start,
                 ),
             )
-            .filter(
-                TaskInstance.dag_id
-                == CANARY_DAG,  # Redundant, for performance.
-            )
+            .filter(TaskInstance.dag_id == CANARY_DAG)  # Redundant, for performance.
             .all()
         )
 
@@ -412,8 +381,19 @@ class MetricsCollector(object):
         t_state = GaugeMetricFamily(
             "airflow_task_status",
             "Shows the number of task instances with particular status",
-            labels=["tag", "dag_id", "task_id", "owner", "status", "cadence", "severity",
-                "alert_target", "instant_slack_alert", "alert_classification"],
+            labels=[
+                "tag",
+                "dag_id",
+                "task_id",
+                "owner",
+                "status",
+                "cadence",
+                "severity",
+                "alert_target",
+                "instant_slack_alert",
+                "alert_classification",
+                "sla",
+            ],
         )
         for task in task_info:
             t_state.add_metric(
@@ -427,9 +407,10 @@ class MetricsCollector(object):
                     task.severerity or "none",
                     task.alert_target or "none",
                     task.instant_slack_alert or "none",
-                    task.alert_classification or "none"
+                    task.alert_classification or "none",
+                    task.sla or "none",
                 ],
-                task.value
+                task.value,
             )
         yield t_state
 
@@ -439,11 +420,13 @@ class MetricsCollector(object):
             labels=["task_id", "dag_id", "execution_date"],
         )
         for task in get_task_duration_info():
-            task_duration_value = (
-                task.end_date - task.start_date
-            ).total_seconds()
+            task_duration_value = (task.end_date - task.start_date).total_seconds()
             task_duration.add_metric(
-                [task.task_id, task.dag_id, task.execution_date.strftime("%Y-%m-%dT%H:%M%S")],
+                [
+                    task.task_id,
+                    task.dag_id,
+                    task.execution_date.strftime("%Y-%m-%dT%H:%M%S"),
+                ],
                 task_duration_value,
             )
         yield task_duration
@@ -454,9 +437,7 @@ class MetricsCollector(object):
             labels=["dag_id", "task_id"],
         )
         for task in get_task_failure_counts():
-            task_failure_count.add_metric(
-                [task.dag_id, task.task_id], task.count
-            )
+            task_failure_count.add_metric([task.dag_id, task.task_id], task.count)
         yield task_failure_count
 
         # Dag Metrics
@@ -464,8 +445,18 @@ class MetricsCollector(object):
         d_state = GaugeMetricFamily(
             "airflow_dag_status",
             "Shows the number of dag starts with this status",
-            labels=["tag", "dag_id", "owner", "status", "cadence", "severity",
-                "alert_target", "instant_slack_alert", "alert_classification"],
+            labels=[
+                "tag",
+                "dag_id",
+                "owner",
+                "status",
+                "cadence",
+                "severity",
+                "alert_target",
+                "instant_slack_alert",
+                "alert_classification",
+                "sla",
+            ],
         )
         for dag in dag_info:
             d_state.add_metric(
@@ -478,9 +469,10 @@ class MetricsCollector(object):
                     dag.severerity or "none",
                     dag.alert_target or "none",
                     dag.instant_slack_alert or "none",
-                    dag.alert_classification or "none"
+                    dag.alert_classification or "none",
+                    dag.sla or "none",
                 ],
-                dag.count
+                dag.count,
             )
         yield d_state
 
@@ -490,9 +482,7 @@ class MetricsCollector(object):
             labels=["dag_id"],
         )
         for dag in get_dag_duration_info():
-            dag_duration_value = (
-                dag.end_date - dag.start_date
-            ).total_seconds()
+            dag_duration_value = (dag.end_date - dag.start_date).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
         yield dag_duration
 
@@ -507,9 +497,7 @@ class MetricsCollector(object):
             dag_scheduling_delay_value = (
                 dag.start_date - dag.execution_date
             ).total_seconds()
-            dag_scheduler_delay.add_metric(
-                [dag.dag_id], dag_scheduling_delay_value
-            )
+            dag_scheduler_delay.add_metric([dag.dag_id], dag_scheduling_delay_value)
         yield dag_scheduler_delay
 
         # XCOM parameters
@@ -542,13 +530,11 @@ class MetricsCollector(object):
             task_scheduling_delay_value = (
                 task.start_date - task.queued_dttm
             ).total_seconds()
-            task_scheduler_delay.add_metric(
-                [task.queue], task_scheduling_delay_value
-            )
+            task_scheduler_delay.add_metric([task.queue], task_scheduling_delay_value)
         yield task_scheduler_delay
 
         num_queued_tasks_metric = GaugeMetricFamily(
-            "airflow_num_queued_tasks", "Airflow Number of Queued Tasks",
+            "airflow_num_queued_tasks", "Airflow Number of Queued Tasks"
         )
 
         num_queued_tasks = get_num_queued_tasks()
@@ -564,19 +550,16 @@ if RBAC:
     class RBACMetrics(FABBaseView):
         route_base = "/admin/metrics/"
 
-        @FABexpose('/')
+        @FABexpose("/")
         def list(self):
-            return Response(generate_latest(), mimetype='text')
+            return Response(generate_latest(), mimetype="text")
 
     # Metrics View for Flask app builder used in airflow with rbac enabled
-    RBACmetricsView = {
-        "view": RBACMetrics(),
-        "name": "Metrics",
-        "category": "Public"
-    }
+    RBACmetricsView = {"view": RBACMetrics(), "name": "Metrics", "category": "Public"}
     ADMIN_VIEW = []
     RBAC_VIEW = [RBACmetricsView]
 else:
+
     class Metrics(BaseView):
         @expose("/")
         def index(self):

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -411,7 +411,7 @@ def get_sla_miss_dags():
                 "alert_classification": dag.alert_classification,
                 "sla_miss": 0,
             }
-            try:
+            if croniter.croniter.is_valid(dag.schedule_interval):
                 cron = croniter.croniter(dag.schedule_interval)
                 expected_last_run = cron.get_prev(datetime)
                 max_execution_date = dag.max_execution_date
@@ -427,7 +427,7 @@ def get_sla_miss_dags():
                         "TIMEZONE": "America/Los_Angeles",
                     },
                 )
-            except croniter.CroniterBadCronError:
+            else:
                 sla_time = dateparser.parse("today " + dag.sla_time)
                 expected_last_run = sla_time.replace(
                     hours=0, minutes=0, seconds=0, microsecond=0
@@ -503,7 +503,7 @@ def get_sla_miss_tasks():
                 "alert_classification": task.alert_classification,
                 "sla_miss": 0,
             }
-            try:
+            if croniter.croniter.is_valid(task.schedule_interval):
                 cron = croniter.croniter(task.schedule_interval)
                 expected_last_run = cron.get_prev(datetime)
                 diff_from_expected = (
@@ -517,7 +517,7 @@ def get_sla_miss_tasks():
                         "TIMEZONE": "America/Los_Angeles",
                     },
                 )
-            except croniter.CroniterBadCronError:
+            else:
                 sla_time = dateparser.parse("today " + task.sla_time)
                 expected_last_run = sla_time.replace(
                     hours=0, minutes=0, seconds=0, microsecond=0

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -413,7 +413,7 @@ def get_sla_miss_tasks():
             session.query(
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
-                max_execution_dt_query.max_execution_dt,
+                TaskInstance.execution_date,
                 GapDagTag.sla_interval,
             )
             .join(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -614,7 +614,9 @@ class MetricsCollector(object):
             diff_from_expected = pendulum.instance(
                 expected_last_run
             ) - pendulum.instance(dag.max_execution_date)
-            sla_time = dateparser.parse(dag.sla_time)
+            sla_time = dateparser.parse(
+                "today " + dag.sla_time, settings={"TIMEZONE": "America/Los_Angeles"}
+            )
             if (
                 pendulum.now("America/Los_Angeles") > sla_time
                 and diff_from_expected > dag.sla_interval
@@ -636,7 +638,9 @@ class MetricsCollector(object):
             diff_from_expected = pendulum.instance(
                 expected_last_run
             ) - pendulum.instance(tasks.max_execution_date)
-            sla_time = dateparser.parse(tasks.sla_time)
+            sla_time = dateparser.parse(
+                "today " + dag.sla_time, settings={"TIMEZONE": "America/Los_Angeles"}
+            )
             if (
                 pendulum.now("America/Los_Angeles") > sla_time
                 and diff_from_expected > tasks.sla_interval

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -423,8 +423,10 @@ def get_sla_miss_dags():
             dag_metrics = {
                 "dag_id": dag.dag_id,
                 "alert_target": dag.alert_target,
-                "alert_external_classification": dag.alert_external_classification,
-                "alert_report_classification": dag.alert_report_classification,
+                "alert_external_classification": dag.alert_external_classification
+                or "missing",
+                "alert_report_classification": dag.alert_report_classification
+                or "missing",
                 "sla_miss": 0,
             }
             max_execution_date = dag.max_execution_date
@@ -528,9 +530,11 @@ def get_sla_miss_tasks():
             task_metrics = {
                 "dag_id": task.dag_id,
                 "task_id": task.task_id,
-                "alert_target": task.alert_target,
-                "alert_external_classification": task.alert_external_classification,
-                "alert_report_classification": task.alert_report_classification,
+                "alert_target": task.alert_target or "missing",
+                "alert_external_classification": task.alert_external_classification
+                or "missing",
+                "alert_report_classification": task.alert_report_classification
+                or "missing",
                 "sla_miss": 0,
             }
             max_execution_date = task.max_execution_date
@@ -615,13 +619,13 @@ class MetricsCollector(object):
                     task.dag_id,
                     task.task_id,
                     task.owners,
-                    task.state or "none",
-                    task.cadence or "none",
-                    task.severity or "none",
-                    task.alert_target or "none",
-                    task.alert_external_classification or "none",
-                    task.alert_report_classification or "none",
-                    task.sla_time or "none",
+                    task.state or "missing",
+                    task.cadence or "missing",
+                    task.severity or "missing",
+                    task.alert_target or "missing",
+                    task.alert_external_classification or "missing",
+                    task.alert_report_classification or "missing",
+                    task.sla_time or "missing",
                 ],
                 task.value,
             )
@@ -675,12 +679,12 @@ class MetricsCollector(object):
                     dag.dag_id,
                     dag.owners,
                     dag.state,
-                    dag.cadence or "none",
-                    dag.severity or "none",
-                    dag.alert_target or "none",
-                    dag.alert_external_classification or "none",
-                    dag.alert_report_classification or "none",
-                    dag.sla_time or "none",
+                    dag.cadence or "missing",
+                    dag.severity or "missing",
+                    dag.alert_target or "missing",
+                    dag.alert_external_classification or "missing",
+                    dag.alert_report_classification or "missing",
+                    dag.sla_time or "missing",
                 ],
                 dag.count,
             )

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -413,7 +413,7 @@ def get_sla_miss_tasks():
             session.query(
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
-                max_execution_dt_query.c.max_execution_dt,
+                max_execution_dt_query.max_execution_dt,
                 GapDagTag.sla_interval,
             )
             .join(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -1,10 +1,12 @@
 """Prometheus exporter for Airflow."""
 import json
 import pickle
+import pendulum
+import os
 from contextlib import contextmanager
 
 from airflow.configuration import conf
-from airflow.models import DagModel, DagRun, TaskInstance, TaskFail, XCom
+from airflow.models import DagModel, DagRun, TaskInstance, TaskFail, XCom, DagTag
 from airflow.plugins_manager import AirflowPlugin
 from airflow.settings import RBAC, Session
 from airflow.utils.state import State
@@ -17,7 +19,10 @@ from sqlalchemy import and_, func
 
 from airflow_prometheus_exporter.xcom_config import load_xcom_config
 
+
 CANARY_DAG = "canary_dag"
+RETENTION_TIME = os.environ.get("PROMETHEUS_METRICS_DAYS", 14)
+TIMEZONE = conf.get("core", "default_timezone")
 
 
 @contextmanager
@@ -36,18 +41,28 @@ def session_scope(session):
 
 def get_dag_state_info():
     """Number of DAG Runs with particular state."""
+    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
         dag_status_query = (
             session.query(
+                DagTag.name,
                 DagRun.dag_id,
                 DagRun.state,
                 func.count(DagRun.state).label("count"),
             )
-            .group_by(DagRun.dag_id, DagRun.state)
+            .filter(
+                DagRun.execution_date > min_date_to_filter,
+                DagRun.state.isnot(None)
+            )
+            .outerjoin(
+                DagTag, DagTag.dag_id == DagRun.dag_id
+            )
+            .group_by(DagTag.name, DagRun.dag_id, DagRun.state)
             .subquery()
         )
         return (
             session.query(
+                dag_status_query.c.name,
                 dag_status_query.c.dag_id,
                 dag_status_query.c.state,
                 dag_status_query.c.count,
@@ -64,6 +79,7 @@ def get_dag_state_info():
 
 def get_dag_duration_info():
     """Duration of successful DAG Runs."""
+    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
         max_execution_dt_query = (
             session.query(
@@ -76,6 +92,7 @@ def get_dag_duration_info():
                 DagModel.is_paused == False,
                 DagRun.state == State.SUCCESS,
                 DagRun.end_date.isnot(None),
+                DagRun.execution_date > min_date_to_filter
             )
             .group_by(DagRun.dag_id)
             .subquery()
@@ -99,6 +116,10 @@ def get_dag_duration_info():
                     ),
                 ),
             )
+            .filter(
+                TaskInstance.start_date.isnot(None),
+                TaskInstance.end_date.isnot(None),
+            )
             .group_by(
                 max_execution_dt_query.c.dag_id,
                 max_execution_dt_query.c.max_execution_dt,
@@ -120,10 +141,6 @@ def get_dag_duration_info():
                     == dag_start_dt_query.c.execution_date,
                 ),
             )
-            .filter(
-                TaskInstance.start_date.isnot(None),
-                TaskInstance.end_date.isnot(None),
-            )
             .all()
         )
 
@@ -135,21 +152,28 @@ def get_dag_duration_info():
 
 def get_task_state_info():
     """Number of task instances with particular state."""
+    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
         task_status_query = (
             session.query(
+                DagTag.name,
                 TaskInstance.dag_id,
                 TaskInstance.task_id,
                 TaskInstance.state,
                 func.count(TaskInstance.dag_id).label("value"),
             )
+            .filter(TaskInstance.execution_date > min_date_to_filter)
+            .outerjoin(
+                DagTag, DagTag.dag_id == TaskInstance.dag_id
+            )
             .group_by(
-                TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state
+                DagTag.name, TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state,
             )
             .subquery()
         )
         return (
             session.query(
+                task_status_query.c.name,
                 task_status_query.c.dag_id,
                 task_status_query.c.task_id,
                 task_status_query.c.state,
@@ -190,6 +214,9 @@ def get_xcom_params(task_id):
             session.query(
                 DagRun.dag_id,
                 func.max(DagRun.execution_date).label("max_execution_dt"),
+            )
+            .filter(
+                TaskInstance.state.isnot(None)
             )
             .group_by(DagRun.dag_id)
             .subquery()
@@ -360,11 +387,11 @@ class MetricsCollector(object):
         t_state = GaugeMetricFamily(
             "airflow_task_status",
             "Shows the number of task instances with particular status",
-            labels=["dag_id", "task_id", "owner", "status"],
+            labels=["tag", "dag_id", "task_id", "owner", "status"],
         )
         for task in task_info:
             t_state.add_metric(
-                [task.dag_id, task.task_id, task.owners, task.state or "none"],
+                [task.name or "none", task.dag_id, task.task_id, task.owners, task.state or "none"],
                 task.value,
             )
         yield t_state
@@ -379,7 +406,7 @@ class MetricsCollector(object):
                 task.end_date - task.start_date
             ).total_seconds()
             task_duration.add_metric(
-                [task.task_id, task.dag_id, str(task.execution_date.date())],
+                [task.task_id, task.dag_id, task.execution_date.strftime("%Y-%m-%dT%H:%M%S")],
                 task_duration_value,
             )
         yield task_duration
@@ -400,10 +427,10 @@ class MetricsCollector(object):
         d_state = GaugeMetricFamily(
             "airflow_dag_status",
             "Shows the number of dag starts with this status",
-            labels=["dag_id", "owner", "status"],
+            labels=["tag", "dag_id", "owner", "status"],
         )
         for dag in dag_info:
-            d_state.add_metric([dag.dag_id, dag.owners, dag.state], dag.count)
+            d_state.add_metric([dag.name or "none", dag.dag_id, dag.owners, dag.state], dag.count)
         yield d_state
 
         dag_duration = GaugeMetricFamily(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -396,7 +396,7 @@ def get_sla_miss_dags():
                 max_execution_dt_query,
                 GapDagTag.dag_id == max_execution_dt_query.c.dag_id,
             )
-            .filter(GapDagTag.sla_interval.isnot(None))
+            .filter(GapDagTag.sla_interval.isnot(None), GapDagTag.task_id.is_(None))
             .all()
         )
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -471,11 +471,11 @@ def get_sla_miss_dags():
                     - pendulum.instance(max_execution_date)
                 ).in_minutes()
 
-            if pendulum.now(
-                "America/Los_Angeles"
-            ) > sla_time and diff_from_expected >= (dag.sla_interval * 24 * 60):
+            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
+                dag.sla_interval * 24 * 60
+            ):
                 dag_metrics["sla_miss"] = 1
-            elif diff_from_expected >= ((dag.sla_interval + 1) * 24 * 60):
+            elif diff_from_expected > ((dag.sla_interval + 1) * 24 * 60):
                 dag_metrics["sla_miss"] = 1
             sla_miss_dags_metrics.append(dag_metrics)
         return sla_miss_dags_metrics
@@ -580,11 +580,11 @@ def get_sla_miss_tasks():
                     - pendulum.instance(max_execution_date)
                 ).in_minutes()
 
-            if pendulum.now(
-                "America/Los_Angeles"
-            ) > sla_time and diff_from_expected >= (task.sla_interval * 24 * 60):
+            if pendulum.now("America/Los_Angeles") > sla_time and diff_from_expected > (
+                task.sla_interval * 24 * 60
+            ):
                 task_metrics["sla_miss"] = 1
-            elif diff_from_expected >= ((task.sla_interval + 1) * 24 * 60):
+            elif diff_from_expected > ((task.sla_interval + 1) * 24 * 60):
                 task_metrics["sla_miss"] = 1
             sla_miss_tasks.append(task_metrics)
         return sla_miss_tasks

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -39,6 +39,7 @@ with session_scope(Session) as session:
 
     class GapDagTag(Base):
         __tablename__ = "gap_dag_tag"
+        dag_id = Column(String, primary_key=True)  # hack to have dag_id as PK
         __table_args__ = {"autoload": True}
 
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -372,7 +372,6 @@ def get_sla_miss_dags():
                 DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
                 DagRun.state == State.SUCCESS,
-                DagRun.end_date.isnot(None),
                 DagRun.execution_date > min_date_to_filter,
             )
             .group_by(DagRun.dag_id)
@@ -388,7 +387,7 @@ def get_sla_miss_dags():
                 max_execution_dt_query,
                 GapDagTag.dag_id == max_execution_dt_query.c.dag_id,
             )
-            .filter(GapDagTag.task_id.is_(None), GapDagTag.sla_interval.isnot(None))
+            .filter(GapDagTag.sla_interval.isnot(None))
         ).all()
 
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -53,6 +53,9 @@ with session_scope(Session) as session:
         alert_report_classification = Column(String)
         sla_interval = Column(Float)
         sla_time = Column(String)
+        group_pagerduty = Column(String)
+        group_business_line = Column(String)
+        inhibit_rule = Column(String)
         latest_successful_run = Column(UtcDateTime)
 
 
@@ -405,6 +408,9 @@ def get_sla_miss_dags():
                 DelayAlertMetaData.alert_target,
                 DelayAlertMetaData.alert_external_classification,
                 DelayAlertMetaData.alert_report_classification,
+                DelayAlertMetaData.group_pagerduty,
+                DelayAlertMetaData.group_business_line,
+                DelayAlertMetaData.inhibit_rule,
                 DelayAlertMetaData.latest_successful_run,
                 max_execution_dt_query.c.schedule_interval,
                 max_execution_dt_query.c.max_execution_date,
@@ -429,6 +435,9 @@ def get_sla_miss_dags():
                 "alert_report_classification": dag.alert_report_classification
                 or MISSING,
                 "sla_miss": 0,
+                "group_pagerduty": dag.group_pagerduty or MISSING,
+                "group_business_line": dag.group_business_line or MISSING,
+                "inhibit_rule": dag.inhibit_rule or MISSING,
             }
             max_execution_date = dag.max_execution_date
             if (
@@ -515,6 +524,9 @@ def get_sla_miss_tasks():
                 DelayAlertMetaData.alert_target,
                 DelayAlertMetaData.alert_external_classification,
                 DelayAlertMetaData.alert_report_classification,
+                DelayAlertMetaData.group_pagerduty,
+                DelayAlertMetaData.group_business_line,
+                DelayAlertMetaData.inhibit_rule,
                 DelayAlertMetaData.latest_successful_run,
             )
             .join(
@@ -538,6 +550,9 @@ def get_sla_miss_tasks():
                 "alert_report_classification": task.alert_report_classification
                 or MISSING,
                 "sla_miss": 0,
+                "group_pagerduty": task.group_pagerduty or MISSING,
+                "group_business_line": task.group_business_line or MISSING,
+                "inhibit_rule": task.inhibit_rule or MISSING,
             }
             max_execution_date = task.max_execution_date
             if (
@@ -614,6 +629,8 @@ class MetricsCollector(object):
                 "alert_external_classification",
                 "alert_report_classification",
                 "sla_time",
+                "network",
+                "business",
             ],
         )
         for task in task_info:
@@ -629,6 +646,8 @@ class MetricsCollector(object):
                     task.alert_external_classification or MISSING,
                     task.alert_report_classification or MISSING,
                     task.sla_time or MISSING,
+                    "network",
+                    "business",
                 ],
                 task.value,
             )
@@ -673,7 +692,10 @@ class MetricsCollector(object):
                 "severity",
                 "alert_target",
                 "alert_external_classification",
-                "alert_report_classification" "sla_time",
+                "alert_report_classification",
+                "sla_time",
+                "network",
+                "business",
             ],
         )
         for dag in dag_info:
@@ -688,6 +710,8 @@ class MetricsCollector(object):
                     dag.alert_external_classification or MISSING,
                     dag.alert_report_classification or MISSING,
                     dag.sla_time or MISSING,
+                    "network",
+                    "business",
                 ],
                 dag.count,
             )
@@ -766,6 +790,9 @@ class MetricsCollector(object):
                 "alert_target",
                 "alert_external_classification",
                 "alert_report_classification",
+                "group_pagerduty",
+                "group_business_line",
+                "inhibit_rule",
             ],
         )
 
@@ -776,6 +803,9 @@ class MetricsCollector(object):
                     dag["alert_target"],
                     dag["alert_external_classification"],
                     dag["alert_report_classification"],
+                    dag["group_pagerduty"],
+                    dag["group_business_line"],
+                    dag["inhibit_rule"],
                 ],
                 dag["sla_miss"],
             )
@@ -791,6 +821,9 @@ class MetricsCollector(object):
                 "alert_target",
                 "alert_external_classification",
                 "alert_report_classification",
+                "group_pagerduty",
+                "group_business_line",
+                "inhibit_rule",
             ],
         )
 
@@ -802,6 +835,9 @@ class MetricsCollector(object):
                     tasks["alert_target"],
                     tasks["alert_external_classification"],
                     tasks["alert_report_classification"],
+                    tasks["group_pagerduty"],
+                    tasks["group_business_line"],
+                    tasks["inhibit_rule"],
                 ],
                 tasks["sla_miss"],
             )

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -27,6 +27,7 @@ from airflow_prometheus_exporter.xcom_config import load_xcom_config
 CANARY_DAG = "canary_dag"
 RETENTION_TIME = os.environ.get("PROMETHEUS_METRICS_DAYS", 14)
 TIMEZONE = conf.get("core", "default_timezone")
+MISSING = "missing"
 
 
 @contextmanager
@@ -422,11 +423,11 @@ def get_sla_miss_dags():
         for dag in dags:
             dag_metrics = {
                 "dag_id": dag.dag_id,
-                "alert_target": dag.alert_target or "missing",
+                "alert_target": dag.alert_target or MISSING,
                 "alert_external_classification": dag.alert_external_classification
-                or "missing",
+                or MISSING,
                 "alert_report_classification": dag.alert_report_classification
-                or "missing",
+                or MISSING,
                 "sla_miss": 0,
             }
             max_execution_date = dag.max_execution_date
@@ -530,11 +531,11 @@ def get_sla_miss_tasks():
             task_metrics = {
                 "dag_id": task.dag_id,
                 "task_id": task.task_id,
-                "alert_target": task.alert_target or "missing",
+                "alert_target": task.alert_target or MISSING,
                 "alert_external_classification": task.alert_external_classification
-                or "missing",
+                or MISSING,
                 "alert_report_classification": task.alert_report_classification
-                or "missing",
+                or MISSING,
                 "sla_miss": 0,
             }
             max_execution_date = task.max_execution_date
@@ -619,13 +620,13 @@ class MetricsCollector(object):
                     task.dag_id,
                     task.task_id,
                     task.owners,
-                    task.state or "missing",
-                    task.cadence or "missing",
-                    task.severity or "missing",
-                    task.alert_target or "missing",
-                    task.alert_external_classification or "missing",
-                    task.alert_report_classification or "missing",
-                    task.sla_time or "missing",
+                    task.state or MISSING,
+                    task.cadence or MISSING,
+                    task.severity or MISSING,
+                    task.alert_target or MISSING,
+                    task.alert_external_classification or MISSING,
+                    task.alert_report_classification or MISSING,
+                    task.sla_time or MISSING,
                 ],
                 task.value,
             )
@@ -679,12 +680,12 @@ class MetricsCollector(object):
                     dag.dag_id,
                     dag.owners,
                     dag.state,
-                    dag.cadence or "missing",
-                    dag.severity or "missing",
-                    dag.alert_target or "missing",
-                    dag.alert_external_classification or "missing",
-                    dag.alert_report_classification or "missing",
-                    dag.sla_time or "missing",
+                    dag.cadence or MISSING,
+                    dag.severity or MISSING,
+                    dag.alert_target or MISSING,
+                    dag.alert_external_classification or MISSING,
+                    dag.alert_report_classification or MISSING,
+                    dag.sla_time or MISSING,
                 ],
                 dag.count,
             )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,10 @@ COPY docker/airflow.sh ${AIRFLOW_USER_HOME}/airflow.sh
 RUN chmod +x ${AIRFLOW_USER_HOME}/airflow.sh
 
 WORKDIR /airflow-prometheus-exporter
-COPY setup.py /airflow-prometheus-exporter/
-COPY README.md /airflow-prometheus-exporter/
-RUN pip install -e .
 
 COPY . /airflow-prometheus-exporter
+RUN pip install -e .
+
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,15 +9,19 @@ RUN set -ex \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
         apt-utils \
+    && apt-get install -yqq sqlite3 \
     && useradd -ms /bin/bash -d ${AIRFLOW_USER_HOME} airflow \
     && pip install -U pip
 
 COPY docker/airflow.sh ${AIRFLOW_USER_HOME}/airflow.sh
 RUN chmod +x ${AIRFLOW_USER_HOME}/airflow.sh
 
-COPY . /airflow-prometheus-exporter
 WORKDIR /airflow-prometheus-exporter
+COPY setup.py /airflow-prometheus-exporter/
+COPY README.md /airflow-prometheus-exporter/
 RUN pip install -e .
+
+COPY . /airflow-prometheus-exporter
 
 RUN chown -R airflow: ${AIRFLOW_USER_HOME}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,9 @@ RUN chmod +x ${AIRFLOW_USER_HOME}/airflow.sh
 
 WORKDIR /airflow-prometheus-exporter
 
+COPY requirements.txt /airflow-prometheus-exporter
+RUN pip install -r requirements.txt
+
 COPY . /airflow-prometheus-exporter
 RUN pip install -e .
 

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 AF_HOME="/usr/local/airflow"
-sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
+sqlite3 "${AF_HOME}/airflow.db" "create table delay_alert_metadata(
     dag_id varchar(250) PRIMARY KEY,
 	task_id varchar(250),
 	cadence varchar(250),

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -8,5 +8,5 @@ sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
 	alert_target varchar(250),
 	instant_slack_alert varchar(250),
     alert_classification varchar(250),
-    sla varchar(8));"
+    sla_interval interval );"
 airflow webserver

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -1,2 +1,12 @@
 #!/bin/bash
+AF_HOME="/usr/local/airflow"
+sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
+    dag_id varchar(250) PRIMARY KEY,
+	task_id varchar(250),
+	cadence varchar(250),
+	severerity varchar(250),
+	alert_target varchar(250),
+	instant_slack_alert varchar(250),
+    alert_classification varchar(250),
+    sla varchar(8));"
 airflow webserver

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -4,10 +4,10 @@ sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
     dag_id varchar(250) PRIMARY KEY,
 	task_id varchar(250),
 	cadence varchar(250),
-	severerity varchar(250),
+	severity varchar(250),
 	alert_target varchar(250),
-	instant_slack_alert varchar(250),
-    alert_classification varchar(250),
+    alert_external_classification varchar(250),
+    alert_report_classification varchar(250),
     sla_interval float,
     sla_time text,
     latest_successful_run text);"

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -8,5 +8,6 @@ sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
 	alert_target varchar(250),
 	instant_slack_alert varchar(250),
     alert_classification varchar(250),
-    sla_interval interval );"
+    sla_interval float,
+    sla_time text);"
 airflow webserver

--- a/docker/airflow.sh
+++ b/docker/airflow.sh
@@ -9,5 +9,6 @@ sqlite3 "${AF_HOME}/airflow.db" "create table gap_dag_tag(
 	instant_slack_alert varchar(250),
     alert_classification varchar(250),
     sla_interval float,
-    sla_time text);"
+    sla_time text,
+    latest_successful_run text);"
 airflow webserver

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+apache-airflow==1.10.12
+croniter==0.3.36
+dateparser==1.0.0
+prometheus_client==0.8.0
+pendulum==1.4.4
+importlib_metadata==1.7.0
+numpy==1.18.1
+marshmallow-sqlalchemy==0.23.1
+marshmallow==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apache-airflow==1.10.12
 croniter==0.3.37
 dateparser==1.0.0
 prometheus_client==0.8.0
-pendulum==1.4.4
+pendulum==2.1.2
 importlib_metadata==1.7.0
 numpy==1.18.1
 marshmallow-sqlalchemy==0.23.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apache-airflow==1.10.12
-croniter==0.3.36
+croniter==0.3.37
 dateparser==1.0.0
 prometheus_client==0.8.0
 pendulum==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ apache-airflow==1.10.12
 croniter==0.3.37
 dateparser==1.0.0
 prometheus_client==0.8.0
-pendulum==2.1.2
+pendulum==1.4.4
 importlib_metadata==1.7.0
 numpy==1.18.1
 marshmallow-sqlalchemy==0.23.1

--- a/runtests
+++ b/runtests
@@ -18,8 +18,10 @@ until $(curl --output /dev/null --silent --show-error --head --fail "${HEALTH_EN
 
     printf '.'
     ATTEMPT_COUNTER=$(($ATTEMPT_COUNTER+1))
+    docker logs airflow-prometheus-exporter
     sleep 10
 done
+
 
 echo "Retrieving metrics from ${METRICS_ENDPOINT}..."
 curl --silent --show-error --fail "${METRICS_ENDPOINT}"
@@ -33,4 +35,3 @@ if test $STATUSCODE -ne 200; then
     # error handling
     exit 1
 fi
-

--- a/runtests
+++ b/runtests
@@ -28,6 +28,8 @@ curl --silent --show-error --fail "${METRICS_ENDPOINT}"
 
 STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" "${METRICS_ENDPOINT}")
 
+
+docker logs airflow-prometheus-exporter
 docker stop airflow-prometheus-exporter
 docker rm airflow-prometheus-exporter
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,3 @@ replace = version='{new_version}'
 [bumpversion:file:airflow_prometheus_exporter/__init__.py]
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
-

--- a/setup.py
+++ b/setup.py
@@ -3,50 +3,49 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-with open('README.md', encoding='utf-8') as readme_file:
+with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-install_requirements = [
-    'prometheus_client==0.8.0',
-    'importlib_metadata==1.7.0',
-],
+install_requirements = (
+    [
+        "apache-airflow==1.10.12",
+        "prometheus_client==0.8.0",
+        "importlib_metadata==1.7.0",
+        "marshmallow-sqlalchemy==0.23.1",
+        "marshmallow==2.21.0",
+    ],
+)  # noqa
 
-extras_require={
-    'dev': [
-        'bumpversion',
-        'tox',
-        'twine',
-    ]
-}
+extras_require = {"dev": ["bumpversion", "tox", "twine"]}  # noqa
 
 setup(
-    author='Robinhood Markets, Inc.',
-    author_email='open-source@robinhood.com',
+    author="Robinhood Markets, Inc.",
+    author_email="open-source@robinhood.com",
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    description='Prometheus Exporter for Airflow Metrics',
+    description="Prometheus Exporter for Airflow Metrics",
     install_requires=install_requirements,
     extras_require=extras_require,
-    license='BSD 3-Clause',
+    license="BSD 3-Clause",
     long_description=readme,
-    long_description_content_type='text/markdown',
-    keywords='airflow_prometheus_exporter',
-    name='airflow_prometheus_exporter',
-    packages=find_packages(include=['airflow_prometheus_exporter']),
+    long_description_content_type="text/markdown",
+    keywords="airflow_prometheus_exporter",
+    name="airflow_prometheus_exporter",
+    packages=find_packages(include=["airflow_prometheus_exporter"]),
     include_package_data=True,
-    url='https://github.com/robinhood/airflow_prometheus_exporter',
-    version='1.0.7',
+    url="https://github.com/robinhood/airflow_prometheus_exporter",
+    version="1.0.7",
     entry_points={
-        'airflow.plugins': [
-            'AirflowPrometheus = airflow_prometheus_exporter.prometheus_exporter:AirflowPrometheusPlugin'
+        "airflow.plugins": [
+            "AirflowPrometheus = airflow_prometheus_exporter.prometheus_exporter:AirflowPrometheusPlugin"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,18 @@
 # -*- coding: utf-8 -*-
 
 """The setup script."""
-
+import pathlib
+import pkg_resources
 from setuptools import find_packages, setup
 
 with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-
+with pathlib.Path("requirements.txt").open() as requirements_txt:
+    install_requires = [
+        str(requirement)
+        for requirement in pkg_resources.parse_requirements(requirements_txt)
+    ]
 extras_require = {"dev": ["bumpversion", "tox", "twine"]}  # noqa
 
 setup(
@@ -23,7 +28,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     description="Prometheus Exporter for Airflow Metrics",
-    install_requires=[],
+    install_requires=install_requires,
     extras_require=extras_require,
     license="BSD 3-Clause",
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,12 @@ with open("README.md", encoding="utf-8") as readme_file:
 install_requirements = (
     [
         "apache-airflow==1.10.12",
+        "croniter==0.3.36",
+        "dateparser==1.0.0",
         "prometheus_client==0.8.0",
+        "pendulum==1.4.4",
         "importlib_metadata==1.7.0",
+        "numpy==1.18.1",
         "marshmallow-sqlalchemy==0.23.1",
         "marshmallow==2.21.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -8,19 +8,6 @@ from setuptools import find_packages, setup
 with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-install_requirements = (
-    [
-        "apache-airflow==1.10.12",
-        "croniter==0.3.36",
-        "dateparser==1.0.0",
-        "prometheus_client==0.8.0",
-        "pendulum==1.4.4",
-        "importlib_metadata==1.7.0",
-        "numpy==1.18.1",
-        "marshmallow-sqlalchemy==0.23.1",
-        "marshmallow==2.21.0",
-    ],
-)  # noqa
 
 extras_require = {"dev": ["bumpversion", "tox", "twine"]}  # noqa
 
@@ -36,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     description="Prometheus Exporter for Airflow Metrics",
-    install_requires=install_requirements,
+    install_requires=[],
     extras_require=extras_require,
     license="BSD 3-Clause",
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 install_requirements = [
-    'apache-airflow>=1.10.4',
-    'prometheus_client>=0.4.2',
+    'prometheus_client==0.8.0',
+    'importlib_metadata==1.7.0',
 ],
 
 extras_require={


### PR DESCRIPTION
# Summary

1. Group alerts that will page by `group_pagerduty`
2. Group alerts that slack external channels by `alert_target` and `dag_id`
3. Group alerts that slack internal channels by `dag_id`
4. Inhibit alerts that only comes on weekdays. 

# Deployment Instructions

1. alertmanager: push_prometheus_config_2
2. airflow_prometheus_exporter: push_airflow_prod